### PR TITLE
updating references for brgandi and license for ctpa

### DIFF
--- a/_datasets/10.23698/aida/ctpa.md
+++ b/_datasets/10.23698/aida/ctpa.md
@@ -64,8 +64,8 @@ datacite:
     "@type": "CreativeWork"
     abstract: |
       Free for use in legal and ethical medical diagnostics research.
-  - name: "AIDA BY CA license"
-    id: "https://datahub.aida.scilifelab.se/10.23698/aida/ctpa#aida-by-ca-license"
+  - name: "AIDA BY license"
+    id: "https://datahub.aida.scilifelab.se/10.23698/aida/ctpa#aida-by-license"
     "@type": "CreativeWork"
     abstract: "Free for use within AIDA with attribution and co-authorship."
   citation:
@@ -129,7 +129,7 @@ Please contact AIDA for terms of access.
   agreement_template_url="https://docs.google.com/document/d/1a020Mukn9cjJF88vEYW9OUUDIc2E3dHbSBQi_jb8Yd0"
   coauthorship="yes" %}
 
-### AIDA BY CA license
+### AIDA BY license
 Copyright
 {{ page.datacite.copyrightYear }}
 {{ page.datacite.copyrightHolder | map: "name" |  join: ", " }}
@@ -138,8 +138,7 @@ Permission to use, copy, modify, and/or distribute this data within Analytic
 Imaging Diagnostics Arena ([AIDA](https://medtech4health.se/aida)) for the
 purpose of medical diagnostics research with or without fee is hereby granted,
 provided that the above copyright notice and this permission notice appear in
-all copies, and that publications resulting from the use of this data include
-the authors of this dataset in the author list and cite the following works:
+all copies, and that publications resulting from the use of this data cite the following works:
 
 {{ page.datacite.author | map: "name" | array_to_sentence_string }}
 ({{ page.datacite.datePublished | date: "%Y" }})
@@ -153,3 +152,4 @@ CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA
 OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
 ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR CHARACTERISTICS OF THIS
 DATA.
+

--- a/_datasets/10.23698/aida/kf2020.md
+++ b/_datasets/10.23698/aida/kf2020.md
@@ -53,7 +53,7 @@ datacite:
     abstract: |
       Free for use in legal and ethical medical diagnostics research.
   - name: "AIDA BY license"
-    id: "https://datahub.aida.scilifelab.se/10.23698/aida/kf2020#aida-by-ca-license"
+    id: "https://datahub.aida.scilifelab.se/10.23698/aida/kf2020#aida-by-license"
     "@type": "CreativeWork"
     abstract: "Free for use within AIDA with attribution."
   citation:

--- a/_datasets/10.23698/aida/synthetic/brgandi.md
+++ b/_datasets/10.23698/aida/synthetic/brgandi.md
@@ -79,8 +79,8 @@ datacite:
     "@id": "https://doi.org/10.7937/K9/TCIA.2017.GJQ7R0EF"
     name: "S. Bakas, H. Akbari, A. Sotiras, M. Bilello, M. Rozycki, J. Kirby, et al., Segmentation Labels and Radiomic Features for the Pre-operative Scans of the TCGA-LGG collection, The Cancer Imaging Archive, 2017. DOI: 10.7937/K9/TCIA.2017.GJQ7R0EF"
   - "@type": "CreativeWork"
-    "@id": "https://doi.org/10.48550/arXiv.2306.02986"
-    name: "Akbar, M. U., Larsson, M., & Eklund, A. (2023). Brain tumor segmentation using synthetic MR images--A comparison of GANs and diffusion models. arXiv:2306.02986."
+    "@id": "https://doi.org/10.1038/s41597-024-03073-x"
+    name: "Usman Akbar, M., Larsson, M., Blystad, I., Eklund, A., Brain tumor segmentation using synthetic MR images - A comparison of GANs and diffusion models. Sci Data 11, 259 (2024)."
 other:
   shortName: "BRGANDI"
   origin: "Synthetic"


### PR DESCRIPTION
- brgandi last paper has been updated
- data sharing license of ctpa has been changed to AIDA BY from AIDA BY CA
- license link for KF2020 has been fixed