### PR TITLE
Added a listing of training events under the support/training page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,10 @@ collections:
   support-projects:
     output: true
     permalink: "/support/projects/:path/"
+  training-events:
+    output: true
+    permaling: "/training/events/:path/"
+
 
 defaults:
   - scope:
@@ -57,6 +61,11 @@ defaults:
   - scope:
       path: ""
       type: "support-projects"
+    values:
+      layout: "default"
+  - scope:
+      path: ""
+      type: "training-events"
     values:
       layout: "default"
   - scope:

--- a/_includes/training-event-header.md
+++ b/_includes/training-event-header.md
@@ -1,0 +1,14 @@
+<!-- <span class="small">{{ page.date | date: "%Y-%m-%d" }}{% if page.end %} - {{ page.end }}{% endif %}</span> -->
+
+<strong>{{ page.blurb }}</strong>
+
+<table class="tight-table">
+{% if page.presentation_url -%}
+  <tr><td><a href="{{ page.presentation_url }}">Presentation</a></td></tr>
+{% endif -%}
+{% if page.code_url -%}
+  <tr><td><a href="{{ page.code_url }}">Code</a></td></tr>
+{% endif -%}
+
+
+</table>

--- a/_training-events/2023-09-06-gnns.md
+++ b/_training-events/2023-09-06-gnns.md
@@ -1,0 +1,16 @@
+---
+title:  Graph Neural Networks and Geometric Deep Learning
+type: workshop          # "workshop", or "presentation"
+code_url: https://github.com/eryl/aida-gnn-workshop-code
+subject: ai # ai, policy, clinical
+presentation_url: https://docs.google.com/presentation/d/1lEZ5jAO5LrFWWfwmepWsxhYy5Rnl8c1OXinkMfYDDmw/edit?usp=sharing
+video_url:
+blurb: >
+  Workshop on Graph Neural Networks and geometric deep learning for digital pathology
+---
+
+{% include training-event-header.md %}
+
+
+One of the major new developments in deep learning is that of Geometric Deep learning, a framework which unifies many of the common successful neural networks under a geometric umbrella. 
+In this workshop we’ll give a concise overview of Geometric Deep Learning with a focus on what Graph Neural Networks are and how they can be practically applied using the Pytorch Geometric framework. As an example application, we will use Graph Neural Networks to classify cell graphs extracted from whole slide images for digital pathology.

--- a/_training-events/2023-09-07-transformer.md
+++ b/_training-events/2023-09-07-transformer.md
@@ -1,0 +1,14 @@
+---
+title: AIDA Transformers for vision
+type: workshop          # "workshop", or "presentation"
+code_url: https://github.com/eryl/aida-transformers-workshop-code
+subject: ai # ai, policy, clinical
+presentation_url: https://docs.google.com/presentation/d/1bpqI_xwBGUT5saXS6y52U7RO-o2xSXWPT-M5a6Mbq68/edit?usp=sharing
+video_url:
+blurb: >
+  An overview of Transformers and how to use them for vision tasks
+---
+
+{% include training-event-header.md %}
+
+Introduced in 2017, Transformers have come to dominate the Natural Language Processing field in just a few years. While the architecture was first applied to language tasks, in this workshop we will explore how this very general neural network architecture can be applied to arbitrary tasks and in particular how they can be used for computer vision. We will explore recent trends in vision Transformers with examples from medical imaging.

--- a/_training-events/2024-03-19-multimodal-and-contrastive-learning.md
+++ b/_training-events/2024-03-19-multimodal-and-contrastive-learning.md
@@ -1,0 +1,15 @@
+---
+title: Multimodal and constrastive learning
+type: workshop          # "workshop", or "presentation"
+code_url: https://github.com/eryl/aida-workshop-contrastive-learning
+subject: ai # ai, policy, clinical
+presentation_url: https://docs.google.com/presentation/d/1sW-picZcWhqV6zCjJKGGqgLQaD2pdfMJ/edit?usp=sharing&ouid=116285713938211495704&rtpof=true&sd=true
+video_url:
+blurb: >
+  Workshop on multimodal and contrastive learning
+---
+
+{% include training-event-header.md %}
+
+
+Multimodal learning combines data types like text and images to improve predictive models and provide alternatives of manual labeling. During the workshop we will have a practical approach to understanding how multimodal learning can be implemented using contrastive learning with deep neural networks. The focus will be on readily available multimodal data combining text and images but what you learn in the workshop can be generalized to any combination of modalities.

--- a/_training-events/2024-03-20-computational-efficency.md
+++ b/_training-events/2024-03-20-computational-efficency.md
@@ -1,0 +1,14 @@
+---
+title: Computation efficiency
+type: workshop          # "workshop", or "presentation"
+code_url: https://github.com/eryl/aida-workshop-profiling
+subject: ai # ai, policy, clinical
+presentation_url: https://docs.google.com/presentation/d/1DU_cAQYHfvAD4vPH91oH5huNqX0SoAnz/edit?usp=sharing&ouid=116285713938211495704&rtpof=true&sd=true
+video_url:
+blurb: >
+  Workshop on profiling for computation efficiency
+---
+
+{% include training-event-header.md %}
+
+Efficiency is key in AI development. Performance bottlenecks can increase the training time by orders of magnitude. In this workshop, our focus will be on addressing common problems with computational performance of AI pipelines, in particular how to deal with data loading bottlenecks. Through this session, we will explore tools to profile python code, how to find computational bottlenecks as well as implementing strategies for improvement.

--- a/_training-events/2024-09-03-reproducible-ml.md
+++ b/_training-events/2024-09-03-reproducible-ml.md
@@ -1,0 +1,21 @@
+---
+title: Reproducible Machine Learning Research
+type: workshop          # "workshop", or "presentation"
+code_url: https://github.com/eryl/aida-reporoducible-ai
+subject: ai # ai, policy, clinical
+presentation_url: https://docs.google.com/presentation/d/1qlGOkq6K10NC2-6rzIVRmBoJijhg8OVP/edit?usp=sharing&ouid=116285713938211495704&rtpof=true&sd=true
+video_url:
+blurb: >
+  Workshop on tracking and configuring your Machine Learning experiments
+---
+
+{% include training-event-header.md %}
+
+
+A deep dive into automating experiments to achieve both reproducibility and extendability in machine learning research. This session will explore MLFlow, a powerful library for experiment tracking, and cover techniques for configuring experiments and optimizing hyperparameters. Learn how to create machine learning science that not only delivers deterministic reproducibility but also yields generalizable results.
+
+ - Strategies for reproducible and extendable research
+ - In-depth exploration of MLFlow for experiment tracking
+ - Techniques for flexible experiment configuration and hyperparameter optimization
+
+Who Should Attend: This workshop is tailored for experienced Python users familiar with training machine learning models. While the techniques presented are broadly applicable to any Python-based framework, PyTorch will be used as the primary example.

--- a/_training-events/2024-09-04-dali-workshop.md
+++ b/_training-events/2024-09-04-dali-workshop.md
@@ -1,0 +1,20 @@
+---
+title: Model computational optimization
+type: workshop          # "workshop", or "presentation"
+code_url: https://github.com/eryl/aida-dali-workshop
+subject: ai # ai, policy, clinical
+presentation_url: https://docs.google.com/presentation/d/1LfEJCGOd98Xv6ymymV39ats1zPy0G3XU/edit?usp=sharing&ouid=116285713938211495704&rtpof=true&sd=true
+video_url:
+blurb: >
+  Workshop on Model computational optimization
+---
+
+{% include training-event-header.md %}
+
+Address the common bottleneck of data loading in neural network training. This workshop focuses on data augmentation challenges in imaging, with a particular emphasis on medical imaging. Discover how to use NVIDIA's DALI framework to offload data augmentation to the GPU, enhancing training efficiency and reducing processing time.
+
+ -Practical implementation of NVIDIA DALI for data loading
+ -Techniques to optimize GPU usage for faster training
+ - Solutions to overcome data augmentation bottlenecks
+
+Who Should Attend: Ideal for attendees with experience in training machine learning models using PyTorch Vision. While DALI can be integrated with other frameworks like TensorFlow or Jax, the focus will be on its application with PyTorch.

--- a/training/index.md
+++ b/training/index.md
@@ -2,4 +2,15 @@
 title: "Training"
 description: "Training events and materials."
 ---
-This page will contain AIDA Data Hub training events and materials.
+
+### Material from training events {#training}
+Here is material from previous training events, please follow the links to find more information
+
+<ul style="padding-left: 0px;">
+{% for event in site.training-events %}
+    <li style="display: block; padding-bottom: 1ex;" date="{{ event.date }}"><span class="small">{{ event.date | date: "%Y-%m-%d" }}</span> <br/> 
+    <strong><a href="{{ event.url }}">{{ event.title }}</a></strong> <br/> 
+    {{ event.blurb | markdownify | replace: '<p>', '' | replace: '</p>', ''}}</li>
+{% endfor %}
+</ul>
+


### PR DESCRIPTION
This adds training events under the support/training section. For now it's just a listing of the events where the information on them lists the presentation and code for the existing workshops.