### PR TITLE
making pages visible

### DIFF
--- a/_datasets/10.23698/aida/scapis-ct-site-1-body.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-1-body.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden:
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-1-casc.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-1-casc.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-1-ccta.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-1-ccta.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-1-lung.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-1-lung.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-2-body.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-2-body.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-2-casc.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-2-casc.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-2-ccta.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-2-ccta.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-2-lung.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-2-lung.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-3-body.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-3-body.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-3-casc.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-3-casc.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-3-ccta.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-3-ccta.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-3-lung.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-3-lung.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-4-body.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-4-body.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-4-casc.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-4-casc.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-4-ccta.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-4-ccta.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-4-lung.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-4-lung.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-5-body.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-5-body.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-5-casc.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-5-casc.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-5-ccta.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-5-ccta.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-5-lung.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-5-lung.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-6-body.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-6-body.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-6-casc.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-6-casc.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-6-ccta.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-6-ccta.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_datasets/10.23698/aida/scapis-ct-site-6-lung.md
+++ b/_datasets/10.23698/aida/scapis-ct-site-6-lung.md
@@ -1,5 +1,5 @@
 ---
-hidden: yes
+hidden: 
 layout: dataset-scapis
 scapis: yes
 datacite:

--- a/_layouts/dataset-scapis.html
+++ b/_layouts/dataset-scapis.html
@@ -42,6 +42,9 @@
     <main id="content" class="main-content" role="main">
       <nav><p class="small"><a href="/">AIDA Data Hub</a> » <a href="/datasets">Datasets</a> » <a href="{{ page.datacite["@id"] }}">{{ page.other.shortName }}</a></p></nav>
 
+        <p><b>
+          The information provided on this page will be updated soon.
+        </b></p>
       {% if page.hidden %}
         <p><b>
           This page describes a dataset that has not yet been shared on the data

--- a/datasets/scapis/index.md
+++ b/datasets/scapis/index.md
@@ -47,7 +47,7 @@ Please contact us for support or more information!
 {{ datasets }} datasets: {% include human_friendly_filesize bytes=bytes %},
 {{ scans }} scans, {{ annotations }} annotations. [More metrics...](../../metrics)
 
-The full SCAPIS data is being transfered and is expected to become available for sharing in August.
+The full SCAPIS image data is available for sharing at AIDA Data Hub.
 
 <div class="dataset-table">
   <table>


### PR DESCRIPTION
- Hidden tag has been removed from SCAPIS landing pages; "The information provided on this page will be updated soon." has been added instead. 
- "The full SCAPIS image data is available for sharing at AIDA Data Hub." has been added to SCAPIS datasets page
