### PR TITLE
Remove references to public register of facilitated sharing.

### DIFF
--- a/_datasets/10.23698/aida/lund-probe.md
+++ b/_datasets/10.23698/aida/lund-probe.md
@@ -161,7 +161,7 @@ Free for use in legal and ethical medical diagnostics research.
 Please contact the dataset provider for terms of access.
 Template agreement here: [Data Sharing Agreement LUND-PROBE template.pdf](/assets/docs/Data Sharing Agreement LUND-PROBE template.pdf)
 
-{% include access-request-blurb.md coauthorship=false %}
+{% include access-request-blurb.md coauthorship=false agreement_template_url="https://datahub.aida.scilifelab.se/assets/docs/Data Sharing Agreement LUND-PROBE template.pdf" %}
 
 ### AIDA BY license
 Copyright

--- a/_includes/access-request-email-research-or-education.md
+++ b/_includes/access-request-email-research-or-education.md
@@ -10,12 +10,4 @@ BRIEF_DESCRIPTION_OF_PLANNED_ACTIVITIES_HERE
 
 Dataset: {{ include.dataset_url }}
 
-Also, I would like to ALTERNATIVELY_WOULD_NOT_LIKE_TO be included in the public record of data sharing facilitated by AIDA:
-
-https://docs.google.com/spreadsheets/d/1fl2BwZJ4rivOKzOCy5pAnxU8N1CyoF86BTCnH-rBV04
-
-which is used to facilitate scientific discussion, and to show what good AIDA has been to the global research community.
-
-(If "not", then only the institution/department information will be included. This choice of personal participation is not weighed into the access request eligibility evaluation.)
-
 /MY_NAME

--- a/_includes/access-request-email-research.md
+++ b/_includes/access-request-email-research.md
@@ -26,12 +26,4 @@ Institution postal address: POSTAL_ADDRESS
 Name of authorized signatory: SIGNATORY_NAME (cc here)
 Title of authorized signatory: SIGNATORY_TITLE
 
-Also, I would like to ALTERNATIVELY_WOULD_NOT_LIKE_TO be included in the public record of data sharing facilitated by AIDA:
-
-https://docs.google.com/spreadsheets/d/1fl2BwZJ4rivOKzOCy5pAnxU8N1CyoF86BTCnH-rBV04
-
-which is used to facilitate scientific discussion, and to show what good AIDA has been to the global research community.
-
-(If "not", then only institution/department information will be included.)
-
 /MY_NAME


### PR DESCRIPTION
Also refer to the specific agreement template fro lund-probe on its landing page.