### PR TITLE
Fix reference list margins

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -272,6 +272,13 @@ span.clearicon input {
 .info-box ol.references > li {
     list-style: none;
 }
+
+// We add space between the list items, but not below the last one
+.info-box ol.references > li:not(:last-child) {
+  margin-bottom: 1em; 
+}
+
+
 .info-box ol.references > li:before {
     content: "[" counter(list) "] ";
     counter-increment: list;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -273,11 +273,9 @@ span.clearicon input {
     list-style: none;
 }
 
-// We add space between the list items, but not below the last one
 .info-box ol.references > li:not(:last-child) {
   margin-bottom: 1em; 
 }
-
 
 .info-box ol.references > li:before {
     content: "[" counter(list) "] ";


### PR DESCRIPTION
The reference lists with more than one reference looked like a compact wall of texts. This adds a small margin after each list item in the reference list of the info box (but not after the last list item).